### PR TITLE
CI: set up cross-platform Java CI pipeline with GitHub Actions

### DIFF
--- a/.github/workflow/gradle.yml
+++ b/.github/workflow/gradle.yml
@@ -1,0 +1,50 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@master
+
+      - name: Set up repository
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+          java-package: jdk+fx
+
+      - name: Build and check with Gradle
+        run: ./gradlew check
+
+      - name: Perform IO redirection test (*NIX)
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (MacOS)
+        if: always() && runner.os == 'macOS'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (Windows)
+        if: always() && runner.os == 'Windows'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        shell: cmd
+        run: runtest.bat


### PR DESCRIPTION
- Added a new workflow file ("Java CI") to automatically build and test the project on push and pull_request events.
- Configured a build matrix to run on ubuntu-latest, macos-latest, and windows-latest for broad platform coverage.
- Included steps to:
  - Check out the repository (with a specific checkout for the master branch).
  - Merge the current commit using a forceful checkout.
  - Validate the Gradle Wrapper via the gradle/wrapper-validation-action.
  - Set up JDK 17 with JavaFX support using actions/setup-java.
  - Build the project and run tests using './gradlew check'.
  - Execute IO redirection tests on Linux, macOS, and Windows with respective scripts.

These changes ensure consistent, automated testing and build verification across multiple operating systems.